### PR TITLE
Specify files to publish in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "url": "https://github.com/jonschlinkert/preserve/blob/master/LICENSE-MIT"
   },
   "main": "index.js",
+  "files": [
+    "index.js"
+  ],
   "engines": {
     "node": ">=0.10.0"
   },


### PR DESCRIPTION
Use the `files` field in package.json to specify essential files.
This reduces the number of files published to npm (currently 10).

https://docs.npmjs.com/files/package.json#files
